### PR TITLE
MIP compatibility: added package.json pointing to smittytone source .py files

### DIFF
--- a/ht16k33matrix.py
+++ b/ht16k33matrix.py
@@ -1,5 +1,5 @@
 # Import the base class
-from .ht16k33 import HT16K33
+from ht16k33 import HT16K33
 
 class HT16K33Matrix(HT16K33):
     """

--- a/ht16k33matrix.py
+++ b/ht16k33matrix.py
@@ -1,5 +1,5 @@
 # Import the base class
-from ht16k33 import HT16K33
+from .ht16k33 import HT16K33
 
 class HT16K33Matrix(HT16K33):
     """

--- a/package.json
+++ b/package.json
@@ -2,39 +2,39 @@
   "urls": [
     [
       "/lib/ht16k33/__init__.py",
-      "github:smittytone/HT16K33-Python/mpy/__init__.py"
+      "github:ubidefeo/HT16K33-Python/mpy/__init__.py"
     ],
     [
       "/lib/ht16k33/ht16k33.mpy",
-      "github:smittytone/HT16K33-Python/mpy/ht16k33.mpy"
+      "github:ubidefeo/HT16K33-Python/mpy/ht16k33.mpy"
     ],
     [
       "/lib/ht16k33/ht16k33matrix.mpy",
-      "github:smittytone/HT16K33-Python/mpy/ht16k33matrix.mpy"
+      "github:ubidefeo/HT16K33-Python/mpy/ht16k33matrix.mpy"
     ],
     [
       "/lib/ht16k33/ht16k33matrixcolour.mpy",
-      "github:smittytone/HT16K33-Python/mpy/ht16k33matrixcolour.mpy"
+      "github:ubidefeo/HT16K33-Python/mpy/ht16k33matrixcolour.mpy"
     ],
     [
       "/lib/ht16k33/ht16k33matrixfeatherwing.mpy",
-      "github:smittytone/HT16K33-Python/mpy/ht16k33matrixfeatherwing.mpy"
+      "github:ubidefeo/HT16K33-Python/mpy/ht16k33matrixfeatherwing.mpy"
     ],
     [
       "/lib/ht16k33/ht16k33segment.mpy",
-      "github:smittytone/HT16K33-Python/mpy/ht16k33segment.mpy"
+      "github:ubidefeo/HT16K33-Python/mpy/ht16k33segment.mpy"
     ],
     [
       "/lib/ht16k33/ht16k33segment14.mpy",
-      "github:smittytone/HT16K33-Python/mpy/ht16k33segment14.mpy"
+      "github:ubidefeo/HT16K33-Python/mpy/ht16k33segment14.mpy"
     ],
     [
       "/lib/ht16k33/ht16k33segmentbig.mpy",
-      "github:smittytone/HT16K33-Python/mpy/ht16k33segmentbig.mpy"
+      "github:ubidefeo/HT16K33-Python/mpy/ht16k33segmentbig.mpy"
     ],
     [
       "/lib/ht16k33/ht16k33segmentgen.mpy",
-      "github:smittytone/HT16K33-Python/mpy/ht16k33segmentgen.mpy"
+      "github:ubidefeo/HT16K33-Python/mpy/ht16k33segmentgen.mpy"
     ]
   ],
   "deps": [],

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "urls": [
     [
-      "/lib/ht16k33/__init__.py.mpy",
-      "github:smittytone/HT16K33-Python/mpy/__init__.py.mpy"
+      "/lib/ht16k33/__init__.py",
+      "github:smittytone/HT16K33-Python/mpy/__init__.py"
     ],
     [
       "/lib/ht16k33/ht16k33.mpy",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,40 @@
 {
   "urls": [
     [
-      "/lib/ht16k33/i2c_lcd.mpy",
-      "github:smittytone/HT16K33-Python/mpy/i2c_lcd.mpy"
+      "/lib/ht16k33/__init__.py.mpy",
+      "github:smittytone/HT16K33-Python/mpy/__init__.py.mpy"
     ],
     [
-      "/lib/ht16k33/i2c_lcd_backlight.mpy",
-      "github:smittytone/HT16K33-Python/mpy/i2c_lcd_backlight.mpy"
+      "/lib/ht16k33/ht16k33.mpy",
+      "github:smittytone/HT16K33-Python/mpy/ht16k33.mpy"
     ],
     [
-      "/lib/ht16k33/i2c_lcd_screen.mpy",
-      "github:smittytone/HT16K33-Python/mpy/i2c_lcd_screen.mpy"
+      "/lib/ht16k33/ht16k33matrix.mpy",
+      "github:smittytone/HT16K33-Python/mpy/ht16k33matrix.mpy"
+    ],
+    [
+      "/lib/ht16k33/ht16k33matrixcolour.mpy",
+      "github:smittytone/HT16K33-Python/mpy/ht16k33matrixcolour.mpy"
+    ],
+    [
+      "/lib/ht16k33/ht16k33matrixfeatherwing.mpy",
+      "github:smittytone/HT16K33-Python/mpy/ht16k33matrixfeatherwing.mpy"
+    ],
+    [
+      "/lib/ht16k33/ht16k33segment.mpy",
+      "github:smittytone/HT16K33-Python/mpy/ht16k33segment.mpy"
+    ],
+    [
+      "/lib/ht16k33/ht16k33segment14.mpy",
+      "github:smittytone/HT16K33-Python/mpy/ht16k33segment14.mpy"
+    ],
+    [
+      "/lib/ht16k33/ht16k33segmentbig.mpy",
+      "github:smittytone/HT16K33-Python/mpy/ht16k33segmentbig.mpy"
+    ],
+    [
+      "/lib/ht16k33/ht16k33segmentgen.mpy",
+      "github:smittytone/HT16K33-Python/mpy/ht16k33segmentgen.mpy"
     ]
   ],
   "deps": [],

--- a/package.json
+++ b/package.json
@@ -1,39 +1,39 @@
 {
   "urls": [
     [
-      "/lib/ht16k33/__init__.py",
+      "ht16k33/__init__.py",
       "github:ubidefeo/HT16K33-Python/__init__.py"
     ],
     [
-      "/lib/ht16k33/ht16k33.mpy",
+      "ht16k33/ht16k33.mpy",
       "github:ubidefeo/HT16K33-Python/mpy/ht16k33.mpy"
     ],
     [
-      "/lib/ht16k33/ht16k33matrix.mpy",
+      "ht16k33/ht16k33matrix.mpy",
       "github:ubidefeo/HT16K33-Python/mpy/ht16k33matrix.mpy"
     ],
     [
-      "/lib/ht16k33/ht16k33matrixcolour.mpy",
+      "ht16k33/ht16k33matrixcolour.mpy",
       "github:ubidefeo/HT16K33-Python/mpy/ht16k33matrixcolour.mpy"
     ],
     [
-      "/lib/ht16k33/ht16k33matrixfeatherwing.mpy",
+      "ht16k33/ht16k33matrixfeatherwing.mpy",
       "github:ubidefeo/HT16K33-Python/mpy/ht16k33matrixfeatherwing.mpy"
     ],
     [
-      "/lib/ht16k33/ht16k33segment.mpy",
+      "ht16k33/ht16k33segment.mpy",
       "github:ubidefeo/HT16K33-Python/mpy/ht16k33segment.mpy"
     ],
     [
-      "/lib/ht16k33/ht16k33segment14.mpy",
+      "ht16k33/ht16k33segment14.mpy",
       "github:ubidefeo/HT16K33-Python/mpy/ht16k33segment14.mpy"
     ],
     [
-      "/lib/ht16k33/ht16k33segmentbig.mpy",
+      "ht16k33/ht16k33segmentbig.mpy",
       "github:ubidefeo/HT16K33-Python/mpy/ht16k33segmentbig.mpy"
     ],
     [
-      "/lib/ht16k33/ht16k33segmentgen.mpy",
+      "ht16k33/ht16k33segmentgen.mpy",
       "github:ubidefeo/HT16K33-Python/mpy/ht16k33segmentgen.mpy"
     ]
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "urls": [
     [
       "/lib/ht16k33/__init__.py",
-      "github:ubidefeo/HT16K33-Python/mpy/__init__.py"
+      "github:ubidefeo/HT16K33-Python/__init__.py"
     ],
     [
       "/lib/ht16k33/ht16k33.mpy",

--- a/package.json
+++ b/package.json
@@ -2,39 +2,39 @@
   "urls": [
     [
       "ht16k33/__init__.py",
-      "github:ubidefeo/HT16K33-Python/__init__.py"
+      "github:smittytone/HT16K33-Python/__init__.py"
     ],
     [
       "ht16k33/ht16k33.mpy",
-      "github:ubidefeo/HT16K33-Python/mpy/ht16k33.mpy"
+      "github:smittytone/HT16K33-Python/ht16k33.py"
     ],
     [
-      "ht16k33/ht16k33matrix.mpy",
-      "github:ubidefeo/HT16K33-Python/mpy/ht16k33matrix.mpy"
+      "ht16k33/ht16k33matrix.py",
+      "github:smittytone/HT16K33-Python/ht16k33matrix.py"
     ],
     [
-      "ht16k33/ht16k33matrixcolour.mpy",
-      "github:ubidefeo/HT16K33-Python/mpy/ht16k33matrixcolour.mpy"
+      "ht16k33/ht16k33matrixcolour.py",
+      "github:smittytone/HT16K33-Python/ht16k33matrixcolour.py"
     ],
     [
-      "ht16k33/ht16k33matrixfeatherwing.mpy",
-      "github:ubidefeo/HT16K33-Python/mpy/ht16k33matrixfeatherwing.mpy"
+      "ht16k33/ht16k33matrixfeatherwing.py",
+      "github:smittytone/HT16K33-Python/ht16k33matrixfeatherwing.py"
     ],
     [
-      "ht16k33/ht16k33segment.mpy",
-      "github:ubidefeo/HT16K33-Python/mpy/ht16k33segment.mpy"
+      "ht16k33/ht16k33segment.py",
+      "github:smittytone/HT16K33-Python/ht16k33segment.py"
     ],
     [
-      "ht16k33/ht16k33segment14.mpy",
-      "github:ubidefeo/HT16K33-Python/mpy/ht16k33segment14.mpy"
+      "ht16k33/ht16k33segment14.py",
+      "github:smittytone/HT16K33-Python/ht16k33segment14.py"
     ],
     [
-      "ht16k33/ht16k33segmentbig.mpy",
-      "github:ubidefeo/HT16K33-Python/mpy/ht16k33segmentbig.mpy"
+      "ht16k33/ht16k33segmentbig.py",
+      "github:smittytone/HT16K33-Python/ht16k33segmentbig.py"
     ],
     [
-      "ht16k33/ht16k33segmentgen.mpy",
-      "github:ubidefeo/HT16K33-Python/mpy/ht16k33segmentgen.mpy"
+      "ht16k33/ht16k33segmentgen.py",
+      "github:smittytone/HT16K33-Python/ht16k33segmentgen.py"
     ]
   ],
   "deps": [],

--- a/package.json
+++ b/package.json
@@ -1,39 +1,35 @@
 {
   "urls": [
     [
-      "ht16k33/__init__.py",
-      "github:smittytone/HT16K33-Python/__init__.py"
-    ],
-    [
-      "ht16k33/ht16k33.mpy",
+      "ht16k33.py",
       "github:smittytone/HT16K33-Python/ht16k33.py"
     ],
     [
-      "ht16k33/ht16k33matrix.py",
+      "ht16k33matrix.py",
       "github:smittytone/HT16K33-Python/ht16k33matrix.py"
     ],
     [
-      "ht16k33/ht16k33matrixcolour.py",
+      "ht16k33matrixcolour.py",
       "github:smittytone/HT16K33-Python/ht16k33matrixcolour.py"
     ],
     [
-      "ht16k33/ht16k33matrixfeatherwing.py",
+      "ht16k33matrixfeatherwing.py",
       "github:smittytone/HT16K33-Python/ht16k33matrixfeatherwing.py"
     ],
     [
-      "ht16k33/ht16k33segment.py",
+      "ht16k33segment.py",
       "github:smittytone/HT16K33-Python/ht16k33segment.py"
     ],
     [
-      "ht16k33/ht16k33segment14.py",
+      "ht16k33segment14.py",
       "github:smittytone/HT16K33-Python/ht16k33segment14.py"
     ],
     [
-      "ht16k33/ht16k33segmentbig.py",
+      "ht16k33segmentbig.py",
       "github:smittytone/HT16K33-Python/ht16k33segmentbig.py"
     ],
     [
-      "ht16k33/ht16k33segmentgen.py",
+      "ht16k33segmentgen.py",
       "github:smittytone/HT16K33-Python/ht16k33segmentgen.py"
     ]
   ],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "urls": [
+    [
+      "/lib/ht16k33/i2c_lcd.mpy",
+      "github:smittytone/HT16K33-Python/mpy/i2c_lcd.mpy"
+    ],
+    [
+      "/lib/ht16k33/i2c_lcd_backlight.mpy",
+      "github:smittytone/HT16K33-Python/mpy/i2c_lcd_backlight.mpy"
+    ],
+    [
+      "/lib/ht16k33/i2c_lcd_screen.mpy",
+      "github:smittytone/HT16K33-Python/mpy/i2c_lcd_screen.mpy"
+    ]
+  ],
+  "deps": [],
+  "version": "3.5.0"
+}


### PR DESCRIPTION
hi @smittytone 

I use this library with my students and we got used to installing some libs using `mip` both from within the REPL and from `mpremote`.
This `package.json` adds `mip` compatibility from a GH source.

If it's merged, you'll be able to just use the following commands:
* `mpremote mip install github:smittytone/HT16K33-Python` from host machine shell
* `mip.install('github:smittytone/HT16K33-Python')` from a MicroPython board connected to internet with a configured network

`mip` will source the correct files and install them inside the board's `/lib` so they can easily be imported once they're in the MicroPython PATH.

I had initially tested placing them in the `/lib/ht16k33` folder, but this entails changing all the examples and follow dot notation for imports, breaking old code.
I have reverted to the simplest installation mode

since it's in my fork, you can try the following on a MicroPython board running a recent firmware with `mip` support.

```
import mip
mip.install('github:ubidefeo/HT16K33-Python')
```

Hope you'll want to merge this one in 😄 

ciao.ubi