### PR TITLE
Extend 'set_blink_rate()' to turn off display with value of '-1'

### DIFF
--- a/ht16k33/ht16k33.py
+++ b/ht16k33/ht16k33.py
@@ -17,13 +17,14 @@ class HT16K33:
     HT16K33_GENERIC_SYSTEM_OFF = 0x20
     HT16K33_GENERIC_DISPLAY_ADDRESS = 0x00
     HT16K33_GENERIC_CMD_BRIGHTNESS = 0xE0
-    HT16K33_GENERIC_CMD_BLINK = 0x81
+    HT16K33_GENERIC_CMD_BLINK = 0x80
 
     # *********** PRIVATE PROPERTIES **********
 
     i2c = None
     address = 0
     brightness = 15
+    display_on = 1
     flash_rate = 0
 
     # *********** CONSTRUCTOR **********
@@ -45,10 +46,16 @@ class HT16K33:
         Args:
             rate (int): The chosen flash rate. Default: 0Hz (no flash).
         """
+        if rate < 0:
+            self.display_on = 0
+            rate = 0
+        else:
+            self.display_on = 1
+
         allowed_rates = (0, 2, 1, 0.5)
         assert rate in allowed_rates, "ERROR - Invalid blink rate set in set_blink_rate()"
         self.blink_rate = allowed_rates.index(rate) & 0x03
-        self._write_cmd(self.HT16K33_GENERIC_CMD_BLINK | self.blink_rate << 1)
+        self._write_cmd(self.HT16K33_GENERIC_CMD_BLINK | self.blink_rate << 1 | self.display_on)
 
     def set_brightness(self, brightness=15):
         """

--- a/ht16k33/ht16k33.py
+++ b/ht16k33/ht16k33.py
@@ -47,7 +47,7 @@ class HT16K33:
             rate (int): The chosen flash rate. Default: 0Hz (no flash).
         """
         if rate < 0:
-            self.display_on = 0
+            self.display_on = not self.display_on
             rate = 0
         else:
             self.display_on = 1
@@ -101,11 +101,13 @@ class HT16K33:
         """
         self._write_cmd(self.HT16K33_GENERIC_SYSTEM_ON)
         self._write_cmd(self.HT16K33_GENERIC_DISPLAY_ON)
+        display_on = 1
 
     def power_off(self):
         """
         Power on the controller and display.
         """
+        display_on = 0
         self._write_cmd(self.HT16K33_GENERIC_DISPLAY_OFF)
         self._write_cmd(self.HT16K33_GENERIC_SYSTEM_OFF)
 


### PR DESCRIPTION
I have a project with multiple modules, when 'blink()' was enabled they blinked a slightly different rates... which looked funky.

The register for blinking also includes a 'display_on' bit, so I access that with a vaule of '-1' to turn off the display(s). Set a normal blink rate to turn display(s) back on.

Tested on the 'HT16K33Segment' from Adafruit.