### PR TITLE
rotation function for 14-segment display

### DIFF
--- a/ht16k33/ht16k33segment14.py
+++ b/ht16k33/ht16k33segment14.py
@@ -266,11 +266,9 @@ class HT16K33Segment14(HT16K33):
             for i in range(0, 8, 2):
                 a = self.buffer[i] + (self.buffer[i+1] << 8)
 
-                '''
                 b11 = a & 0x0800
                 b13 = a & 0x2000
-                a =  (a & 0x57FF) | (b11 < 2) | (b13 > 2)
-                '''
+                a =  (a & 0x57FF) | (b11 << 2) | (b13 >> 2)
 
                 b = (a & 0b0000011100000111) << 3
                 c = (a & 0b0011100000111000) >> 3
@@ -280,11 +278,9 @@ class HT16K33Segment14(HT16K33):
                 a &= 0b0100000000000000     # Decimal Point remains
                 a = (a | b | c | d | e)
 
-                '''
                 b11 = a & 0x0800
                 b13 = a & 0x2000
-                a =  (a & 0x57FF) | (b11 < 2) | (b13 > 2)
-                '''
+                a =  (a & 0x57FF) | (b11 << 2) | (b13 >> 2)
 
                 self.buffer[i] = a & 0xFF
                 self.buffer[i+1] = a >> 8

--- a/ht16k33/ht16k33segment14.py
+++ b/ht16k33/ht16k33segment14.py
@@ -48,6 +48,7 @@ class HT16K33Segment14(HT16K33):
 
     def __init__(self, i2c, i2c_address=0x70, is_ht16k33=False, board=UNKNOWN, do_enable_display=True):
         self.buffer = bytearray(16)
+        self.is_rotated = False
 
         # FROM 4.1.0
         # Provide backwards compatibility with 4.0.x
@@ -63,6 +64,16 @@ class HT16K33Segment14(HT16K33):
 
 
     # *********** PUBLIC FUNCTIONS **********
+
+    def rotate(self):
+        """
+        Rotate/flip the segment display.
+
+        Returns:
+            The instance (self)
+        """
+        self.is_rotated = not self.is_rotated
+        return self
 
     def set_glyph(self, glyph, digit=0, has_dot=False):
         """
@@ -227,6 +238,58 @@ class HT16K33Segment14(HT16K33):
         # FROM 4.1.0 Use the `board` property rather than `is_ht16k33`.
         # This only works on SparkFun Alphanumeric.
         return self._set_furniture(self.VK16K33_SEG14_DECIMAL_BYTE, is_on)
+
+    def draw(self):
+        """
+        Writes the current display buffer to the display itself.
+
+        Call this method after updating the buffer to update
+        the LED itself. Rotation handled here.
+        """
+        if self.is_rotated:
+            # Swap msb/lsb for digits 0,3 and 1,2
+            a = self.buffer[0]
+            b = self.buffer[1]
+            self.buffer[0] = self.buffer[6]
+            self.buffer[1] = self.buffer[7]
+            self.buffer[6] = a
+            self.buffer[7] = b
+
+            a = self.buffer[2]
+            b = self.buffer[3]
+            self.buffer[2] = self.buffer[4]
+            self.buffer[3] = self.buffer[5]
+            self.buffer[4] = a
+            self.buffer[5] = b
+
+            # Rotate segments for each msb/lsb
+            for i in range(0, 8, 2):
+                a = self.buffer[i] + (self.buffer[i+1] << 8)
+
+                '''
+                b11 = a & 0x0800
+                b13 = a & 0x2000
+                a =  (a & 0x57FF) | (b11 < 2) | (b13 > 2)
+                '''
+
+                b = (a & 0b0000011100000111) << 3
+                c = (a & 0b0011100000111000) >> 3
+                d = (a & 0b0000000001000000) << 1
+                e = (a & 0b0000000010000000) >> 1
+
+                a &= 0b0100000000000000     # Decimal Point remains
+                a = (a | b | c | d | e)
+
+                '''
+                b11 = a & 0x0800
+                b13 = a & 0x2000
+                a =  (a & 0x57FF) | (b11 < 2) | (b13 > 2)
+                '''
+
+                self.buffer[i] = a & 0xFF
+                self.buffer[i+1] = a >> 8
+
+        self._render()
 
     # *********** PRIVATE FUNCTIONS (DO NOT CALL) **********
 


### PR DESCRIPTION
First pass at doing a rotation function for the 14segment displays.

I'm using ECBUYING ones, two displays with left one inverted. I have done this so my device can flip to a rotated display and keep the possibility of decimal point between Seconds and Frames.

Whole display shows:
HH MM SS.FF

At present the outer segments (used for numbers) work fine, but patch gives weirdness with the diagonal segments. I don't really understand how the B11 and B13 bit-swap is supposed to work....
